### PR TITLE
Limit the log file size 

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@
   version = "=1.8.12"
 
 [[constraint]]
-  branch = "develop"
+  branch = "master"
   name = "github.com/republicprotocol/republic-go"
 
 [[constraint]]


### PR DESCRIPTION
**TODO : CHANGE THE BASE BRANCH TO NIGHTLY**

The file size of journal output can be limited by setting `SystemMaxUse=XXX` in the `/etc/systemd/journald.conf`. It doesn't have any default value. We should set it to a reasonable value when deploying. It might also be a good idea doing vacuum of the log files when auto-updater is triggered. i.e.
```bash
sudo journalctl --vacuum-size=1G
sudo journalctl --vacuum-time=1years
```

clean up `apt` cache to free up storage
