### PR TITLE
Resizing instance size

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can also specify the region and instance type you want to use for the Darkno
 ```sh
 darknode up --name my-first-darknode --aws --aws-access-key YOUR-AWS-ACCESS-KEY --aws-secret-key YOUR-AWS-SECRET-KEY --aws-region eu-west-1 --aws-instance t2.small
 ``` 
-
+The default instance type is `t3.small` and region will be random.
 You can find all available regions and instance types at [AWS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
 
 You can also associate the darknode to an elastic IP by providing the `EIP-ALLOCATION-ID` of the elastic IP. 
@@ -86,7 +86,7 @@ You can also specify the region and droplet size you want to use for the Darknod
 darknode up --name my-first-darknode --do --do-token YOUR-API-TOKEN --do-region nyc1 --do-droplet 8gb
 ``` 
 
-The default droplet size is `s-4vcpu-8gb` and region will be random. 
+The default droplet size is `s-2vcpu-2gb` and region will be random. 
 Be aware some region and droplet size are not available to all users.
 
 You can find all available regions and droplet size slug by using the digital ocean [API](https://developers.digitalocean.com/documentation/v2/#regions).
@@ -108,6 +108,25 @@ darknode destroy my-first-darknode --force
 ```
 
 We do not recommend using the `--force` argument unless you are developing custom tools that manage your Darknodes automatically.
+
+### Resize the darknode 
+
+To resize the instance type your darknode is using, open a terminal and run :
+```sh
+darknode resize YOUR-DARKNODE-NAME NEW_INSTANCE_TYPE
+```
+
+For AWS, you'll need to replace the `NEW_INSTANCE_TYPE` field with AWS EC2 intance type , i.e. `t3.micro`, `t2.medium`. 
+```sh
+darknode resize YOUR-DARKNODE-NAME t3.small
+```
+You can find all available instance types at [AWS](https://aws.amazon.com/ec2/instance-types).
+
+For digital ocean, you'll need to replace the `NEW_INSTANCE_TYPE` field with digital ocean droplet slug, i.e. `s-1vcpu-2gb`, `s-1vcpu-1gb`.
+```sh
+darknode resize YOUR-DARKNODE-NAME s-1vcpu-2gb
+``` 
+This usually takes a bit longer than AWS as it's recreating the instance. You can find droplet slugs info from [Digital Ocean Standard plans](https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/) and [DigitalOcean API Slugs](https://slugs.do-api.dev/) 
 
 
 ### List all Darknodes

--- a/README.md
+++ b/README.md
@@ -109,24 +109,24 @@ darknode destroy my-first-darknode --force
 
 We do not recommend using the `--force` argument unless you are developing custom tools that manage your Darknodes automatically.
 
-### Resize the darknode 
+### Resize a Darknode 
 
-To resize the instance type your darknode is using, open a terminal and run :
+To resize the instance type your Darknode is using, open a terminal and run:
 ```sh
 darknode resize YOUR-DARKNODE-NAME NEW_INSTANCE_TYPE
 ```
 
-For AWS, you'll need to replace the `NEW_INSTANCE_TYPE` field with AWS EC2 intance type , i.e. `t3.micro`, `t2.medium`. 
+If you are using AWS, you will need to replace the `NEW_INSTANCE_TYPE` field with the AWS EC2 instance type you wish to use, e.g. `t3.micro` or `t2.medium`."
 ```sh
 darknode resize YOUR-DARKNODE-NAME t3.small
 ```
 You can find all available instance types at [AWS](https://aws.amazon.com/ec2/instance-types).
 
-For digital ocean, you'll need to replace the `NEW_INSTANCE_TYPE` field with digital ocean droplet slug, i.e. `s-1vcpu-2gb`, `s-1vcpu-1gb`.
+If you are using DigitalOcean, you will need to replace the `NEW_INSTANCE_TYPE` field with the DigitalOcean droplet slug you wish to use, e.g. `s-1vcpu-2gb` or `s-1vcpu-1gb`.
 ```sh
 darknode resize YOUR-DARKNODE-NAME s-1vcpu-2gb
 ``` 
-This usually takes a bit longer than AWS as it's recreating the instance. You can find droplet slugs info from [Digital Ocean Standard plans](https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/) and [DigitalOcean API Slugs](https://slugs.do-api.dev/) 
+This may take longer than AWS as it recreates the instance. You can find all available droplet slugs at [Digital Ocean Standard plans](https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/) and [DigitalOcean API Slugs](https://slugs.do-api.dev/) 
 
 
 ### List all Darknodes
@@ -185,15 +185,6 @@ and now run:
 ```sh
 darknode update my-first-darknode --config
 ``` 
-
-### Refund your Darknode
-
-To refund the bond of your darknode after deregistering, open a terminal and run:
-
-```sh
-darknode refund YOUR-DARKNODE-NAME
-``` 
-This will refund the 100,000 REN to the darknode operator address (the one you used to register the darknode).
 
 ### Withdraw balance from the Darknode
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can also specify the region and instance type you want to use for the Darkno
 ```sh
 darknode up --name my-first-darknode --aws --aws-access-key YOUR-AWS-ACCESS-KEY --aws-secret-key YOUR-AWS-SECRET-KEY --aws-region eu-west-1 --aws-instance t2.small
 ``` 
-The default instance type is `t3.small` and region will be random.
+The default instance type is `t3.micro` and region will be random.
 You can find all available regions and instance types at [AWS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
 
 You can also associate the darknode to an elastic IP by providing the `EIP-ALLOCATION-ID` of the elastic IP. 
@@ -86,7 +86,7 @@ You can also specify the region and droplet size you want to use for the Darknod
 darknode up --name my-first-darknode --do --do-token YOUR-API-TOKEN --do-region nyc1 --do-droplet 8gb
 ``` 
 
-The default droplet size is `s-2vcpu-2gb` and region will be random. 
+The default droplet size is `s-1vcpu-1gb` and region will be random. 
 Be aware some region and droplet size are not available to all users.
 
 You can find all available regions and droplet size slug by using the digital ocean [API](https://developers.digitalocean.com/documentation/v2/#regions).

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -72,6 +72,9 @@ var ErrInvalidEthereumAddress = fmt.Errorf("%sinvalid Ethereum address%s", RED, 
 // ErrInvalidSshKeyFile is returned when the ssh key file contains an invalid ssh key.
 var ErrInvalidSshKeyFile = fmt.Errorf("%sinvalid sshkey file%s", RED, RESET)
 
+// ErrInvalidInstanceSize is returned when the given instance size is invalid.
+var ErrInvalidInstanceSize = fmt.Errorf("%sinvalid instance size%s", RED, RESET)
+
 // ErrFailedTx is returned when the transaction gets reverted on Ethereum.
 var ErrFailedTx = fmt.Errorf("%stransaction failed%s", RED, RESET)
 

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -72,7 +72,7 @@ var (
 	AwsInstanceFlag = cli.StringFlag{
 		Name:  "aws-instance",
 		Value: "t3.micro",
-		Usage: "An optional AWS EC2 instance type (default: t3.small)",
+		Usage: "An optional AWS EC2 instance type (default: t3.micro)",
 	}
 	AwsElasticIpFlag = cli.StringFlag{
 		Name:  "aws-elastic-ip",
@@ -103,6 +103,6 @@ var (
 	DoSizeFlag = cli.StringFlag{
 		Name:  "do-droplet",
 		Value: "s-1vcpu-1gb",
-		Usage: "An optional digital ocean droplet size (default: s-2vcpu-2gb)",
+		Usage: "An optional digital ocean droplet size (default: s-1vcpu-1gb)",
 	}
 )

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -71,7 +71,7 @@ var (
 	}
 	AwsInstanceFlag = cli.StringFlag{
 		Name:  "aws-instance",
-		Value: "t3.small",
+		Value: "t3.micro",
 		Usage: "An optional AWS EC2 instance type (default: t3.small)",
 	}
 	AwsElasticIpFlag = cli.StringFlag{
@@ -102,7 +102,7 @@ var (
 	}
 	DoSizeFlag = cli.StringFlag{
 		Name:  "do-droplet",
-		Value: "s-2vcpu-2gb",
+		Value: "s-1vcpu-1gb",
 		Usage: "An optional digital ocean droplet size (default: s-2vcpu-2gb)",
 	}
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "Darknode CLI"
 	app.Usage = "A command-line tool for managing Darknodes."
-	app.Version = "2.2.9"
+	app.Version = "2.2.10"
 
 	// Define sub-commands
 	app.Commands = []cli.Command{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,6 +92,15 @@ func main() {
 				return withdraw(c)
 			},
 		},
+		{
+			Name:  "resize",
+			Usage: "resize the instance type",
+			Flags: []cli.Flag{},
+			Action: func(c *cli.Context) error {
+				return resize(c)
+			},
+		},
+
 		// {
 		// 	Name:  "exec",
 		// 	Usage: "Execute script on nodes",

--- a/cmd/resize.go
+++ b/cmd/resize.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+func resize(ctx *cli.Context) error {
+	name := ctx.Args().First()
+	newSize := ctx.Args().Get(1)
+
+	// Validate the name
+	nodePath, err := validateDarknodeName(name)
+	if err != nil {
+		return err
+	}
+	if newSize == "" {
+		return ErrInvalidInstanceSize
+	}
+
+	// Get main.tf file
+	filePath := path.Join(nodePath, "main.tf")
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	// Check if it's aws or digital ocean
+	if strings.Contains(string(data), `provider "aws"`) {
+		return resizeAwsInstance(data, nodePath, filePath, newSize)
+	} else if strings.Contains(string(data), `provider "digitalocean"`) {
+		return resizeDoInstance(data, nodePath, filePath, newSize)
+	} else {
+		return ErrUnknownProvider
+	}
+}
+
+func resizeAwsInstance(tfFile []byte, nodePath, tfPath, newSize string) error {
+	reg, err := regexp.Compile(`variable "instance_type" \{\s+default = ".+"\s\}`)
+	if err != nil {
+		return err
+	}
+	replacement := fmt.Sprintf("variable \"instance_type\" {\n  default = \"%v\"\n}", newSize)
+	newTF := reg.ReplaceAll(tfFile, []byte(replacement))
+	if err := ioutil.WriteFile(tfPath, newTF, 0644); err != nil {
+		return err
+	}
+
+	// Start running terraform
+	fmt.Printf("\n%sResizing dark nodes ... %s\n", RESET, RESET)
+	apply := fmt.Sprintf("cd %v && terraform apply -auto-approve -no-color", nodePath)
+	err = run("bash", "-c", apply)
+	if err != nil {
+		// revert the `main.tf` file if fail to resize the droplet
+		defer func() {
+			if err := ioutil.WriteFile(tfPath, tfFile, 0644); err != nil {
+				fmt.Println("fail to revert the change to `main.tf` file")
+			}
+		}()
+		return err
+	}
+
+	// Update ip address to the multiAddress.out file
+	update := fmt.Sprintf("cd %v && terraform output multiaddress > multiAddress.out", nodePath)
+	return run("bash", "-c", update)
+}
+
+func resizeDoInstance(tfFile []byte, nodePath, tfPath, newSize string) error {
+	// Replace with the new size in the `main.tf` file
+	reg, err := regexp.Compile(`variable "size" \{\s+default = ".+"\s\}`)
+	if err != nil {
+		return err
+	}
+	replacement := fmt.Sprintf("variable \"size\" {\n\tdefault = \"%v\"\n}", newSize)
+	newTF := reg.ReplaceAll(tfFile, []byte(replacement))
+	if err := ioutil.WriteFile(tfPath, newTF, 0644); err != nil {
+		return err
+	}
+
+	// Mark the droplet as tainted for recreating the droplet
+	taint := fmt.Sprintf("cd %v && terraform taint digitalocean_droplet.darknode", nodePath)
+	err = run("bash", "-c", taint)
+	if err != nil {
+		return err
+	}
+
+	// Start running terraform
+	fmt.Printf("\n%sResizing dark nodes ... %s\n", RESET, RESET)
+	apply := fmt.Sprintf("cd %v && terraform apply -auto-approve -no-color", nodePath)
+	err = run("bash", "-c", apply)
+	if err != nil {
+		// revert the `main.tf` file if fail to resize the droplet
+		defer func() {
+			if err := ioutil.WriteFile(tfPath, tfFile, 0644); err != nil {
+				fmt.Println("fail to revert the change to `main.tf` file")
+			}
+		}()
+		return err
+	}
+
+	// Update ip address to the multiAddress.out file
+	update := fmt.Sprintf("cd %v && terraform output multiaddress > multiAddress.out", nodePath)
+	return run("bash", "-c", update)
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -121,5 +121,5 @@ func sshNode(ctx *cli.Context) error {
 	}
 	keyPairPath := nodePath + "/ssh_keypair"
 
-	return run("ssh", "-i", keyPairPath, "darknode@"+ip)
+	return run("ssh", "-i", keyPairPath, "darknode@"+ip, "-oStrictHostKeyChecking=no")
 }


### PR DESCRIPTION
- Introduce a new command `resize` which allow users to resize the instance on aws and digitalocean. (For DO, it will recreate a new droplet as it doesn't allow decreasing the size of a Droplet’s disk, see [digital ocean](https://www.digitalocean.com/docs/droplets/how-to/resize/))
- Disable known_hosts prompt when first-time sshing into the darknode.
 - Change the default instance type for AWS (`t3.small` -> `t3.micro`) and Digital Ocean (`s-2vcpu-2gb` ->  `s-1vcpu-1gb`) 