### PR TITLE
fix aws setup - missing host argument

### DIFF
--- a/target/resources/instance/aws/aws.tmpl
+++ b/target/resources/instance/aws/aws.tmpl
@@ -124,6 +124,7 @@ resource "aws_instance" "darknode" {
       type        = "ssh"
       user        = "ubuntu"
       private_key = "${file("${var.ssh_private_key_path}")}"
+      host        = self.public_ip
     }
   }
 
@@ -135,6 +136,7 @@ resource "aws_instance" "darknode" {
       type        = "ssh"
       user        = "darknode"
       private_key = "${file("${var.ssh_private_key_path}")}"
+      host        = self.public_ip
     }
   }
 
@@ -145,6 +147,7 @@ resource "aws_instance" "darknode" {
       type        = "ssh"
       user        = "darknode"
       private_key = "${file("${var.ssh_private_key_path}")}"
+      host        = self.public_ip
     }
   }
 


### PR DESCRIPTION
Following current instructions to setup a darknode on AWS gives an error. It's missing the 'host' argument in the terraform deployment template. 

`The argument "host" is required, but no definition was found.`

Setting it to the instance public IP solves it.

<img width="1231" alt="Screenshot 2019-08-05 at 17 09 10" src="https://user-images.githubusercontent.com/1451524/62475719-e6223880-b7a5-11e9-888a-9d6de6e72631.png">
Haven't validated for DO since no account on DO. Happy to give it a shot if nobody else can.