### PR TITLE
Show darknode provider in `list` command

### DIFF
--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -47,14 +47,18 @@ func listAllNodes(ctx *cli.Context) error {
 		if err != nil {
 			continue
 		}
+		prov, err := getProvider(nodesNames[i])
+		if err != nil {
+			continue
+		}
 
-		nodes = append(nodes, []string{nodesNames[i], address, ip, string(tags), ethAddress.Hex()})
+		nodes = append(nodes, []string{nodesNames[i], address, ip, string(prov), string(tags), ethAddress.Hex()})
 	}
 
 	if len(nodes) > 0 {
-		fmt.Printf("%-20s | %-30s | %-15s | %-20s | %-45s \n", "name", "Address", "ip", "tags", "Ethereum Address")
+		fmt.Printf("%-20s | %-30s | %-15s | %-10s | %-20s | %-45s \n", "name", "Address", "ip", "provider", "tags", "Ethereum Address")
 		for i := range nodes {
-			fmt.Printf("%-20s | %-30s | %-15s | %-20s | %-45s\n", nodes[i][0], nodes[i][1], nodes[i][2], nodes[i][3], nodes[i][4])
+			fmt.Printf("%-20s | %-30s | %-15s | %-10s | %-20s | %-45s\n", nodes[i][0], nodes[i][1], nodes[i][2], nodes[i][3], nodes[i][4], nodes[i][5])
 		}
 		return nil
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -66,6 +66,30 @@ func getID(nodeDirectory string) (string, error) {
 	return multi.ValueForProtocol(identity.RepublicCode)
 }
 
+// getProvider returns the provider of a darknode instance.
+func getProvider(name string) (Provider, error) {
+	// Validate the name
+	nodePath, err := validateDarknodeName(name)
+	if err != nil {
+		return "", err
+	}
+
+	// Get main.tf file
+	filePath := path.Join(nodePath, "main.tf")
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	// Check if it's aws or digital ocean
+	if strings.Contains(string(data), `provider "aws"`) {
+		return AWS, nil
+	} else if strings.Contains(string(data), `provider "digitalocean"`) {
+		return DIGITAL_OCEAN, nil
+	}
+	return "", ErrUnknownProvider
+}
+
 // getNodesByTags return the names of the nodes having the given tags.
 func getNodesByTags(tags string) ([]string, error) {
 	files, err := ioutil.ReadDir(Directory + "/darknodes")


### PR DESCRIPTION
This PR adds the darknode provider when calling the `list` command. Useful for #22 